### PR TITLE
add ghostland status page checker

### DIFF
--- a/check_url.py
+++ b/check_url.py
@@ -2,11 +2,18 @@ import requests
 import re
 import time
 from datetime import datetime
-import pytz  
+import pytz
+from bs4 import BeautifulSoup
 
 SOURCE_URL = "https://opennx.github.io"
-TIMEZONE = "America/Sao_Paulo"  # Change as needed
+TIMEZONE = "America/Sao_Paulo"
 
+# Mapping Ghostland shops to their status pages
+GHOSTLAND_SHOPS = {
+    "nx.ghostland.at": "https://status.ghostland.at/797146088",
+    "nx-retro.ghostland.at": "https://status.ghostland.at/799726659",
+    "nx-saves.ghostland.at": "https://status.ghostland.at/797836101"
+}
 
 def fetch_hosts():
     try:
@@ -18,9 +25,33 @@ def fetch_hosts():
         print(f"Failed to fetch host list: {e}")
         return []
 
-from bs4 import BeautifulSoup
+def check_individual_ghostland_status(status_url):
+    try:
+        response = requests.get(status_url, timeout=10)
+        response.raise_for_status()
+        content = response.text.lower()
+
+        if "operational" in content:
+            return "✅ Operational (via Ghostland status page)"
+        if "partial outage" in content:
+            return "⚠️ Partial outage (via Ghostland status page)"
+        if "major outage" in content or "down" in content:
+            return "❌ Major outage (via Ghostland status page)"
+
+        return "⚠️ Unknown status (via Ghostland status page)"
+
+    except Exception as e:
+        print(f"Error checking Ghostland status page {status_url}: {e}")
+        return None
 
 def check_url_status(url):
+    # Check Ghostland status page first
+    if url in GHOSTLAND_SHOPS:
+        status = check_individual_ghostland_status(GHOSTLAND_SHOPS[url])
+        if status:
+            return status
+
+    # Try HTTPS and fallback to HTTP
     def try_fetch(scheme):
         try:
             full_url = f"{scheme}://{url}"
@@ -34,10 +65,8 @@ def check_url_status(url):
             print(f"{scheme.upper()} error for {url}: {e}")
             return None
 
-    # Try HTTPS first
     response = try_fetch("https")
     if response is None:
-        # Try HTTP fallback
         response = try_fetch("http")
         if response is None:
             return "❌ DOWN (HTTPS and HTTP failed)"
@@ -45,7 +74,6 @@ def check_url_status(url):
     if response.status_code != 200:
         return f"❌ DOWN ({response.status_code})"
 
-    # Check if site is forcing a file download
     content_disposition = response.headers.get('Content-Disposition', '').lower()
     if 'attachment' in content_disposition:
         return "❌ Forced download (bad config)"
@@ -65,16 +93,11 @@ def check_url_status(url):
     # Parse using BeautifulSoup
     soup = BeautifulSoup(content, "html.parser")
     title_text = soup.title.string.strip().lower() if soup.title else ""
-
-    # Step 1: Maintenance
-    if "maintenance" in title_text:
-        return "⚠️ Under maintenance"
-
     headers = " ".join(h.get_text().lower() for h in soup.find_all(["h1", "h2"]))
-    if "maintenance" in headers:
+
+    if "maintenance" in title_text or "maintenance" in headers:
         return "⚠️ Under maintenance"
 
-    # Step 2: Broken indicators
     broken_indicators = [
         "default web page", "site not found", "502 bad gateway",
         "this site can’t be reached", "<title>error", "error 403"
@@ -82,27 +105,20 @@ def check_url_status(url):
     if any(bad in content for bad in broken_indicators):
         return "❌ Error/Placeholder content"
 
-    # Step 3: Possibly blank content
     if len(content.strip()) < 300:
         return "⚠️ Possibly blank or minimal content"
 
-    # Step 4: Working indicators
     working_indicators = [
         ".nsp", ".xci", "/files/", "tinfoil", ".nsz", ".iso",
-        "eshop", "switch", "game", "region", "release"
+        "eshop", "shop", "switch", "game", "region", "release"
     ]
     if any(good in content for good in working_indicators):
         return "✅ OK"
 
     return "⚠️ Unknown"
 
-
-
 def generate_readme(results):
-    # Sort by status (optional)
     results.sort(key=lambda x: x[1])
-
-    # Timezone-aware last updated
     tz = pytz.timezone(TIMEZONE)
     now = datetime.now(tz)
     last_updated = now.strftime('%Y-%m-%d %H:%M:%S %OZ%Z')
@@ -119,7 +135,9 @@ def generate_readme(results):
 
         f.write("### Status Legend\n")
         f.write("- ✅ OK — Shop is online and serving valid content\n")
+        f.write("- ✅ Operational (via [Ghostland status page](https://status.ghostland.at))\n")
         f.write("- ⚠️ Possibly blank — Low-content or unusual page\n")
+        f.write("- ⚠️ Partial outage — Detected via [Ghostland status page](https://status.ghostland.at)\n")
         f.write("- ❌ DOWN/Error — Shop not reachable or shows error\n\n")
 
         f.write("### Current Shop Status\n\n")


### PR DESCRIPTION
Ghostland shops now always use their status page as the first and primary check.